### PR TITLE
 Implemented some operations in the webservice authorization.

### DIFF
--- a/client/src/app/login/main.vue
+++ b/client/src/app/login/main.vue
@@ -24,7 +24,7 @@
       */
       submit() {
         const payload = { email: this.email, password: this.password }
-        this.$http.post('login', payload).then((response) => {
+        this.$http.post('auth/issue', payload).then((response) => {
           this.handleResponse(response)
         })
       },

--- a/client/src/components/root/navbar.vue
+++ b/client/src/components/root/navbar.vue
@@ -17,6 +17,7 @@
     methods: {
       ...mapActions(['setToken', 'setUser']),
       logout() {
+        this.$http.post('auth/revoke');
         this.setToken('')
         this.setUser({})
         this.$router.push({ name: 'login.index' })

--- a/webservice/app/Exceptions/Handler.php
+++ b/webservice/app/Exceptions/Handler.php
@@ -6,6 +6,7 @@ use Exception;
 use Illuminate\Auth\AuthenticationException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 class Handler extends ExceptionHandler
 {
@@ -45,8 +46,15 @@ class Handler extends ExceptionHandler
      */
     public function render($request, Exception $exception)
     {
-        if ($request->expectsJson() && $exception instanceof HttpException) {
-            return $this->handleExceptionJsonResponse($exception);
+        if ($request->expectsJson()) {
+
+            if ($exception instanceof UnauthorizedHttpException) {
+                return $this->handleUnauthorizedHttpException($exception);
+            }
+
+            if ($exception instanceof HttpException) {
+                return $this->handleExceptionJsonResponse($exception);
+            }
         }
 
         return parent::render($request, $exception);
@@ -64,6 +72,31 @@ class Handler extends ExceptionHandler
         return response()->json([
             'messages' => [$exception->getMessage()],
         ], $exception->getStatusCode());
+    }
+
+    /**
+     * Handle the JSON response for the UnauthorizedHttpException.
+     *
+     * @param UnauthorizedHttpException $exception
+     * @return \Illuminate\Http\JsonResponse
+     */
+    protected function handleUnauthorizedHttpException(UnauthorizedHttpException $exception)
+    {
+        $headers = $exception->getHeaders();
+
+        if (isset($headers['WWW-Authenticate']) && $headers['WWW-Authenticate'] == 'jwt-auth') {
+
+            $message = $exception->getMessage();
+
+            if(false === !strpos($message, 'expired')) {
+                return response()->json([
+                    'reason' => 'token_expired',
+                    'messages' => [$exception->getMessage()]
+                ], $exception->getStatusCode());
+            }
+        }
+
+        return $this->handleExceptionJsonResponse($exception);
     }
 
     /**

--- a/webservice/app/Http/Controllers/ApiController.php
+++ b/webservice/app/Http/Controllers/ApiController.php
@@ -81,6 +81,19 @@ abstract class ApiController extends Controller
     }
 
     /**
+     * Return a 204 response.
+     *
+     * @param  string $message
+     *
+     * @return \Illuminate\Http\Response
+     */
+    protected function responseWithNoContent()
+    {
+        return $this->setStatusCode(Response::HTTP_NO_CONTENT)
+                    ->response([]);
+    }
+
+    /**
      * Return an error response.
      *
      * @param  mixed $message

--- a/webservice/app/Http/Controllers/AuthController.php
+++ b/webservice/app/Http/Controllers/AuthController.php
@@ -104,6 +104,19 @@ class AuthController extends ApiController
         return $this->responseWithNoContent();
     }
 
+    /**
+     * Refresh the user's token.
+     *
+     * @param Request $request
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function refreshToken(Request $request)
+    {
+        $token = Auth::guard('api')->refresh();
+
+        return $this->response(compact('token'));
+    }
+
     public function username()
     {
         return 'email';

--- a/webservice/app/Http/Controllers/AuthController.php
+++ b/webservice/app/Http/Controllers/AuthController.php
@@ -4,11 +4,10 @@ namespace App\Http\Controllers;
 
 use Illuminate\Foundation\Auth\ThrottlesLogins;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 use Auth;
 use Lang;
 
-class LoginController extends ApiController
+class AuthController extends ApiController
 {
     use ThrottlesLogins;
 
@@ -19,7 +18,7 @@ class LoginController extends ApiController
      * @param Request $request
      * @return \Illuminate\Http\JsonResponse
      */
-    public function login(Request $request)
+    public function issueToken(Request $request)
     {
         // Determine if the user has too many failed login attempts.
         if ($this->hasTooManyLoginAttempts($request)) {
@@ -66,7 +65,7 @@ class LoginController extends ApiController
     /**
      * Return error message after determining invalid credentials.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Illuminate\Http\Request $request
      * @return \Illuminate\Http\JsonResponse
      */
     protected function sendFailedLoginResponse(Request $request)
@@ -79,7 +78,7 @@ class LoginController extends ApiController
     /**
      * Redirect the user after determining they are locked out.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Illuminate\Http\Request $request
      * @return \Illuminate\Http\JsonResponse
      */
     public function sendLockoutResponse(Request $request)
@@ -91,6 +90,18 @@ class LoginController extends ApiController
         $message = Lang::get('auth.throttle', ['seconds' => $seconds]);
 
         return $this->responseWithTooManyRequests($message);
+    }
+
+    /**
+     * Revoke the user's token.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function revokeToken()
+    {
+        Auth::guard('api')->logout();
+
+        return $this->responseWithNoContent();
     }
 
     public function username()

--- a/webservice/app/Http/Kernel.php
+++ b/webservice/app/Http/Kernel.php
@@ -52,6 +52,7 @@ class Kernel extends HttpKernel
         'bindings' => \Illuminate\Routing\Middleware\SubstituteBindings::class,
         'can' => \Illuminate\Auth\Middleware\Authorize::class,
         'guest' => \App\Http\Middleware\RedirectIfAuthenticated::class,
-        'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class
+        'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
+        'jwt.auth' => \Tymon\JWTAuth\Http\Middleware\Authenticate::class
     ];
 }

--- a/webservice/routes/api.php
+++ b/webservice/routes/api.php
@@ -4,9 +4,10 @@ Route::group([
     'middleware' => ['cors', 'api'],
 ], function () {
     Route::post('/auth/issue', 'AuthController@issueToken');
+    Route::post('/auth/refresh', 'AuthController@refreshToken');
 
     Route::group([
-        'middleware' => 'auth:api',
+        'middleware' => 'jwt.auth',
     ], function () {
         Route::post('/auth/revoke', 'AuthController@revokeToken');
         Route::resource('/categories', 'CategoriesController', [

--- a/webservice/routes/api.php
+++ b/webservice/routes/api.php
@@ -3,11 +3,12 @@
 Route::group([
     'middleware' => ['cors', 'api'],
 ], function () {
-    Route::post('/login', 'LoginController@login');
+    Route::post('/auth/issue', 'AuthController@issueToken');
 
     Route::group([
         'middleware' => 'auth:api',
     ], function () {
+        Route::post('/auth/revoke', 'AuthController@revokeToken');
         Route::resource('/categories', 'CategoriesController', [
             'except' => ['create', 'edit'],
         ]);


### PR DESCRIPTION
* LoginController renamed to AuthController

* The authentication route was changed to /auth/issue (suggestion @hernandev ), this change was reflected in the client.

* Added method to revoke token

* Added method to update token

* The authentication middleware now used is the jwt library,
Because with the standard laravel middleware, it is not possible to identify when the token is expired.

I talked to @vedovelli  about the refresh token feature on the client, so we will open a discussion in this PR on how to implement this feature.

I will give an example of how the api returns the response signaling that the token is expired.