### PR TITLE
Suggested alternative for code splitting

### DIFF
--- a/client/src/app/categories/routes.js
+++ b/client/src/app/categories/routes.js
@@ -4,8 +4,8 @@
  * http://router.vuejs.org/en/advanced/lazy-loading.html
  */
 
-const Categories = r => require.ensure([], () => r(require('./main.vue')), 'group-categories')
-const Form = r => require.ensure([], () => r(require('./form.vue')), 'group-categories')
+const Categories = r => require.ensure([], () => r(require('./main.vue')), 'categories-bundle')
+const Form = r => require.ensure([], () => r(require('./form.vue')), 'categories-bundle')
 
 const meta = {
   requiresAuth: true,

--- a/client/src/app/categories/routes.js
+++ b/client/src/app/categories/routes.js
@@ -1,11 +1,26 @@
 /**
- * Group components for code splitting in Web pack
- *
+ * Components are lazy-loaded
  * http://router.vuejs.org/en/advanced/lazy-loading.html
+ *
+ * An alternative syntax, to group all components into a single
+ * Webpack 'chunk', or file is as follows:
+ *
+ * const Categories = r => require.ensure([], () => r(require('./main.vue')), 'categories-bundle')
+ * const Form = r => require.ensure([], () => r(require('./form.vue')), 'categories-bundle')
+ *
  */
 
-const Categories = r => require.ensure([], () => r(require('./main.vue')), 'categories-bundle')
-const Form = r => require.ensure([], () => r(require('./form.vue')), 'categories-bundle')
+const Categories = (resolve) => {
+    require.ensure(['./main'], () => {
+      resolve(require('./main')) // eslint-disable-line global-require
+  })
+}
+
+const Form = (resolve) => {
+    require.ensure(['./form'], () => {
+      resolve(require('./form')) // eslint-disable-line global-require
+  })
+}
 
 const meta = {
   requiresAuth: true,

--- a/client/src/app/categories/routes.js
+++ b/client/src/app/categories/routes.js
@@ -2,25 +2,25 @@
  * Components are lazy-loaded
  * http://router.vuejs.org/en/advanced/lazy-loading.html
  *
- * An alternative syntax, to group all components into a single
- * Webpack 'chunk', or file is as follows:
+ * const Categories = (resolve) => {
+ *   require.ensure(['./main'], () => {
+ *     resolve(require('./main')) // eslint-disable-line global-require
+ *  })
+ * }
  *
- * const Categories = r => require.ensure([], () => r(require('./main.vue')), 'categories-bundle')
- * const Form = r => require.ensure([], () => r(require('./form.vue')), 'categories-bundle')
+ * const Form = (resolve) => {
+ *   require.ensure(['./form'], () => {
+ *     resolve(require('./form')) // eslint-disable-line global-require
+ *  })
+ * }
  *
+ * An alternative syntax used below, to group all components into a single
+ * Webpack 'chunk' and JS file.
  */
 
-const Categories = (resolve) => {
-    require.ensure(['./main'], () => {
-      resolve(require('./main')) // eslint-disable-line global-require
-  })
-}
+const Categories = r => require.ensure([], () => r(require('./main.vue')), 'categories-bundle')
+const Form = r => require.ensure([], () => r(require('./form.vue')), 'categories-bundle')
 
-const Form = (resolve) => {
-    require.ensure(['./form'], () => {
-      resolve(require('./form')) // eslint-disable-line global-require
-  })
-}
 
 const meta = {
   requiresAuth: true,

--- a/client/src/app/categories/routes.js
+++ b/client/src/app/categories/routes.js
@@ -1,19 +1,11 @@
-
 /**
-* Components are lazy-loaded
-* http://router.vuejs.org/en/advanced/lazy-loading.html
-*/
-const Categories = (resolve) => {
-  require.ensure(['./main'], () => {
-    resolve(require('./main')) // eslint-disable-line global-require
-  })
-}
+ * Group components for code splitting in Web pack
+ *
+ * http://router.vuejs.org/en/advanced/lazy-loading.html
+ */
 
-const Form = (resolve) => {
-  require.ensure(['./form'], () => {
-    resolve(require('./form')) // eslint-disable-line global-require
-  })
-}
+const Categories = r => require.ensure([], () => r(require('./main.vue')), 'group-categories')
+const Form = r => require.ensure([], () => r(require('./form.vue')), 'group-categories')
 
 const meta = {
   requiresAuth: true,


### PR DESCRIPTION
Here's a suggested alternative for code splitting application components, as per http://router.vuejs.org/en/advanced/lazy-loading.html (a little further down).

Of course you'd only use the 'group' approach if you wanted to group the list, and form views, and all related 'categories' components into a single JS file. I think this is probably okay, as have a single async source file, split for each model/entity or logical area of the application makes sense, as opposed to a separate JS file for every form/component.