### PR TITLE
Query parameters

### DIFF
--- a/webservice/app/Http/Controllers/ApiController.php
+++ b/webservice/app/Http/Controllers/ApiController.php
@@ -2,25 +2,13 @@
 
 namespace App\Http\Controllers;
 
+use App\Traits\Response;
 use App\Transformers\Transform;
-use Symfony\Component\HttpFoundation\Response;
 use Illuminate\Contracts\Routing\ResponseFactory;
 
 abstract class ApiController extends Controller
 {
-    /**
-     * HTTP Response.
-     *
-     * @var \Illuminate\Contracts\Routing\ResponseFactory
-     */
-    private $response;
-
-    /**
-     * HTTP status code.
-     *
-     * @var int
-     */
-    private $statusCode = Response::HTTP_OK;
+    use Response;
 
     /**
      * Transform.
@@ -39,107 +27,5 @@ abstract class ApiController extends Controller
     {
         $this->response = $response;
         $this->transform = $transform;
-    }
-
-    /**
-     * Return a 429 response.
-     *
-     * @param  string $message
-     *
-     * @return \Illuminate\Http\Response
-     */
-    protected function responseWithTooManyRequests($message = 'Too Many Requests')
-    {
-        return $this->setStatusCode(Response::HTTP_TOO_MANY_REQUESTS)->responseWithError($message);
-    }
-
-    /**
-     * Return a 401 response.
-     *
-     * @param  string $message
-     *
-     * @return \Illuminate\Http\Response
-     */
-    protected function responseWithUnauthorized($message = 'Unauthorized')
-    {
-        return $this->setStatusCode(Response::HTTP_UNAUTHORIZED)->responseWithError($message);
-    }
-
-    /**
-     * Return a 500 response.
-     *
-     * @param  string $message
-     *
-     * @return \Illuminate\Http\Response
-     */
-    protected function responseWithInternalServerError($message = 'Internal Server Error')
-    {
-        return $this->setStatusCode(Response::HTTP_INTERNAL_SERVER_ERROR)->responseWithError($message);
-    }
-
-    /**
-     * Return a 404 response.
-     *
-     * @param  string $message
-     *
-     * @return \Illuminate\Http\Response
-     */
-    protected function responseWithNotFound($message = 'Not Found')
-    {
-        return $this->setStatusCode(Response::HTTP_NOT_FOUND)->responseWithError($message);
-    }
-
-    /**
-     * Return an error response.
-     *
-     * @param  mixed $message
-     *
-     * @return \Illuminate\Http\Response
-     */
-    protected function responseWithError($message)
-    {
-        return $this->response([
-            'messages' => (is_array($message) ? $message : [$message]),
-        ]);
-    }
-
-    /**
-     * Return a 204 response.
-     *
-     * @param  string $message
-     *
-     * @return \Illuminate\Http\Response
-     */
-    protected function responseWithNoContent()
-    {
-        return $this->setStatusCode(Response::HTTP_NO_CONTENT)
-            ->response([]);
-    }
-
-    /**
-     * Return a JSON response.
-     *
-     * @param  mixed  $data
-     * @param  array  $headers
-     *
-     * @return \Illuminate\Http\Response
-     */
-    protected function response($data, array $headers = [])
-    {
-        return $this->response->json($data, $this->statusCode, $headers);
-    }
-
-    /**
-     * Set HTTP status code.
-     *
-     * @param int $statusCode
-     *
-     * @return self
-     */
-    protected function setStatusCode($statusCode)
-    {
-        $this->statusCode = $statusCode;
-
-        return $this;
     }
 }

--- a/webservice/app/Http/Controllers/ApiController.php
+++ b/webservice/app/Http/Controllers/ApiController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers;
 
-use App\Traits\Response;
+use App\Traits\Responses;
 use Illuminate\Http\Request;
 use App\Traits\QueryParameters;
 use App\Transformers\Transform;
@@ -10,7 +10,7 @@ use Illuminate\Contracts\Routing\ResponseFactory;
 
 abstract class ApiController extends Controller
 {
-    use Response, QueryParameters;
+    use Responses, QueryParameters;
 
     /**
      * Transform.

--- a/webservice/app/Http/Controllers/ApiController.php
+++ b/webservice/app/Http/Controllers/ApiController.php
@@ -3,12 +3,14 @@
 namespace App\Http\Controllers;
 
 use App\Traits\Response;
+use Illuminate\Http\Request;
+use App\Traits\QueryParameters;
 use App\Transformers\Transform;
 use Illuminate\Contracts\Routing\ResponseFactory;
 
 abstract class ApiController extends Controller
 {
-    use Response;
+    use Response, QueryParameters;
 
     /**
      * Transform.
@@ -20,11 +22,13 @@ abstract class ApiController extends Controller
     /**
      * Creates a new class instance.
      *
+     * @param Request         $request
      * @param ResponseFactory $response
      * @param Transform       $transform
      */
-    public function __construct(ResponseFactory $response, Transform $transform)
+    public function __construct(Request $request, ResponseFactory $response, Transform $transform)
     {
+        $this->request = $request;
         $this->response = $response;
         $this->transform = $transform;
     }

--- a/webservice/app/Http/Controllers/CategoriesController.php
+++ b/webservice/app/Http/Controllers/CategoriesController.php
@@ -15,8 +15,14 @@ class CategoriesController extends ApiController
      */
     public function index()
     {
+        $sort = $this->getSort();
+        $order = $this->getOrder();
+        $limit = $this->getLimit();
+
+        $categories = Category::orderBy($sort, $order)->paginate($limit);
+
         return $this->response(
-            $this->transform->collection(Category::paginate(10), new CategoryTransformer)
+            $this->transform->collection($categories, new CategoryTransformer)
         );
     }
 

--- a/webservice/app/Http/Controllers/ProductsController.php
+++ b/webservice/app/Http/Controllers/ProductsController.php
@@ -15,8 +15,14 @@ class ProductsController extends ApiController
      */
     public function index()
     {
+        $sort = $this->getSort();
+        $order = $this->getOrder();
+        $limit = $this->getLimit();
+
+        $products = Product::orderBy($sort, $order)->paginate($limit);
+
         return $this->response(
-            $this->transform->collection(Product::paginate(10), new ProductTransformer)
+            $this->transform->collection($products, new ProductTransformer)
         );
     }
 

--- a/webservice/app/Traits/QueryParameters.php
+++ b/webservice/app/Traits/QueryParameters.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Traits;
+
+trait QueryParameters
+{
+    /**
+     * HTTP Request.
+     *
+     * @var \Illuminate\Http\Request
+     */
+    private $request;
+
+    /**
+     * Get order parameter.
+     *
+     * @param  string $default
+     *
+     * @return string
+     */
+    protected function getOrder($default = 'desc')
+    {
+        return $this->getParameter('order', $default);
+    }
+
+    /**
+     * Get sort parameter.
+     *
+     * @param  string $default
+     *
+     * @return string
+     */
+    protected function getSort($default = 'id')
+    {
+        return $this->getParameter('sort', $default);
+    }
+
+    /**
+     * Get limit parameter.
+     *
+     * @param  int $default
+     *
+     * @return int
+     */
+    protected function getLimit($default = 10)
+    {
+        return $this->getParameter('limit', $default);
+    }
+
+    /**
+     * Get query parameter by name.
+     *
+     * @param  string $name
+     * @param  mixed  $default
+     *
+     * @return mixed
+     */
+    protected function getParameter($name, $default = null)
+    {
+        return $this->request->query($name, $default);
+    }
+}

--- a/webservice/app/Traits/QueryParameters.php
+++ b/webservice/app/Traits/QueryParameters.php
@@ -14,41 +14,41 @@ trait QueryParameters
     /**
      * Get order parameter.
      *
-     * @param  string $default
+     * @param  string $order
      *
      * @return string
      */
-    protected function getOrder($default = 'desc')
+    protected function getOrder($order = 'desc')
     {
-        return $this->getParameter('order', $default);
+        return $this->getParameter('order', $order);
     }
 
     /**
      * Get sort parameter.
      *
-     * @param  string $default
+     * @param  string $column
      *
      * @return string
      */
-    protected function getSort($default = 'id')
+    protected function getSort($column = 'id')
     {
-        return $this->getParameter('sort', $default);
+        return $this->getParameter('sort', $column);
     }
 
     /**
      * Get limit parameter.
      *
-     * @param  int $default
+     * @param  int $limit
      *
      * @return int
      */
-    protected function getLimit($default = 10)
+    protected function getLimit($limit = 10)
     {
-        return $this->getParameter('limit', $default);
+        return $this->getParameter('limit', $limit);
     }
 
     /**
-     * Get query parameter by name.
+     * Retrive a query parameter from the request.
      *
      * @param  string $name
      * @param  mixed  $default

--- a/webservice/app/Traits/Response.php
+++ b/webservice/app/Traits/Response.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace App\Traits;
+
+use Illuminate\Contracts\Routing\ResponseFactory;
+use Symfony\Component\HttpFoundation\Response as HttpResponse;
+
+trait Response
+{
+    /**
+     * HTTP Response.
+     *
+     * @var \Illuminate\Contracts\Routing\ResponseFactory
+     */
+    private $response;
+
+    /**
+     * HTTP status code.
+     *
+     * @var int
+     */
+    private $statusCode = HttpResponse::HTTP_OK;
+
+    /**
+     * Return a 429 response.
+     *
+     * @param  string $message
+     *
+     * @return \Illuminate\Http\Response
+     */
+    protected function responseWithTooManyRequests($message = 'Too Many Requests')
+    {
+        return $this->setStatusCode(HttpResponse::HTTP_TOO_MANY_REQUESTS)->responseWithError($message);
+    }
+
+    /**
+     * Return a 401 response.
+     *
+     * @param  string $message
+     *
+     * @return \Illuminate\Http\Response
+     */
+    protected function responseWithUnauthorized($message = 'Unauthorized')
+    {
+        return $this->setStatusCode(HttpResponse::HTTP_UNAUTHORIZED)->responseWithError($message);
+    }
+
+    /**
+     * Return a 500 response.
+     *
+     * @param  string $message
+     *
+     * @return \Illuminate\Http\Response
+     */
+    protected function responseWithInternalServerError($message = 'Internal Server Error')
+    {
+        return $this->setStatusCode(HttpResponse::HTTP_INTERNAL_SERVER_ERROR)->responseWithError($message);
+    }
+
+    /**
+     * Return a 404 response.
+     *
+     * @param  string $message
+     *
+     * @return \Illuminate\Http\Response
+     */
+    protected function responseWithNotFound($message = 'Not Found')
+    {
+        return $this->setStatusCode(HttpResponse::HTTP_NOT_FOUND)->responseWithError($message);
+    }
+
+    /**
+     * Return an error response.
+     *
+     * @param  mixed $message
+     *
+     * @return \Illuminate\Http\Response
+     */
+    protected function responseWithError($message)
+    {
+        return $this->response([
+            'messages' => (is_array($message) ? $message : [$message]),
+        ]);
+    }
+
+    /**
+     * Return a 204 response.
+     *
+     * @param  string $message
+     *
+     * @return \Illuminate\Http\Response
+     */
+    protected function responseWithNoContent()
+    {
+        return $this->setStatusCode(HttpResponse::HTTP_NO_CONTENT)
+            ->response([]);
+    }
+
+    /**
+     * Return a JSON response.
+     *
+     * @param  mixed  $data
+     * @param  array  $headers
+     *
+     * @return \Illuminate\Http\Response
+     */
+    protected function response($data, array $headers = [])
+    {
+        return $this->response->json($data, $this->statusCode, $headers);
+    }
+
+    /**
+     * Set HTTP status code.
+     *
+     * @param int $statusCode
+     *
+     * @return self
+     */
+    protected function setStatusCode($statusCode)
+    {
+        $this->statusCode = $statusCode;
+
+        return $this;
+    }
+}

--- a/webservice/app/Traits/Responses.php
+++ b/webservice/app/Traits/Responses.php
@@ -3,7 +3,6 @@
 namespace App\Traits;
 
 use Symfony\Component\HttpFoundation\Response;
-use Illuminate\Contracts\Routing\ResponseFactory;
 
 trait Responses
 {

--- a/webservice/app/Traits/Responses.php
+++ b/webservice/app/Traits/Responses.php
@@ -2,10 +2,10 @@
 
 namespace App\Traits;
 
+use Symfony\Component\HttpFoundation\Response;
 use Illuminate\Contracts\Routing\ResponseFactory;
-use Symfony\Component\HttpFoundation\Response as HttpResponse;
 
-trait Response
+trait Responses
 {
     /**
      * HTTP Response.
@@ -19,7 +19,7 @@ trait Response
      *
      * @var int
      */
-    private $statusCode = HttpResponse::HTTP_OK;
+    private $statusCode = Response::HTTP_OK;
 
     /**
      * Return a 429 response.
@@ -30,7 +30,7 @@ trait Response
      */
     protected function responseWithTooManyRequests($message = 'Too Many Requests')
     {
-        return $this->setStatusCode(HttpResponse::HTTP_TOO_MANY_REQUESTS)->responseWithError($message);
+        return $this->setStatusCode(Response::HTTP_TOO_MANY_REQUESTS)->responseWithError($message);
     }
 
     /**
@@ -42,7 +42,7 @@ trait Response
      */
     protected function responseWithUnauthorized($message = 'Unauthorized')
     {
-        return $this->setStatusCode(HttpResponse::HTTP_UNAUTHORIZED)->responseWithError($message);
+        return $this->setStatusCode(Response::HTTP_UNAUTHORIZED)->responseWithError($message);
     }
 
     /**
@@ -54,7 +54,7 @@ trait Response
      */
     protected function responseWithInternalServerError($message = 'Internal Server Error')
     {
-        return $this->setStatusCode(HttpResponse::HTTP_INTERNAL_SERVER_ERROR)->responseWithError($message);
+        return $this->setStatusCode(Response::HTTP_INTERNAL_SERVER_ERROR)->responseWithError($message);
     }
 
     /**
@@ -66,7 +66,7 @@ trait Response
      */
     protected function responseWithNotFound($message = 'Not Found')
     {
-        return $this->setStatusCode(HttpResponse::HTTP_NOT_FOUND)->responseWithError($message);
+        return $this->setStatusCode(Response::HTTP_NOT_FOUND)->responseWithError($message);
     }
 
     /**
@@ -92,7 +92,7 @@ trait Response
      */
     protected function responseWithNoContent()
     {
-        return $this->setStatusCode(HttpResponse::HTTP_NO_CONTENT)
+        return $this->setStatusCode(Response::HTTP_NO_CONTENT)
             ->response([]);
     }
 

--- a/webservice/composer.lock
+++ b/webservice/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "6fea655f73e82f3d711c95c19cae7a71",
+    "hash": "9ca2efe3ec5b78f8fdd6d4ec57a3d21e",
     "content-hash": "cef4a0d460343ecc9f744fc6df620b8a",
     "packages": [
         {


### PR DESCRIPTION
Added **query parameters** to **products** and **categories**, as sugested in #73, see examples below.

### 1. Requests

``` bash
/api/categories?limit=20&sort=name&order=asc
```

### 2. Controllers

For now we only have 3 query parameters, and they are **limit, sort** and **order**, but you can retrieve any other parameter by using the `getParameter` method provided by the `QueryParameters` trait, this trait was implemented in the `ApiController`, so you will always have the methods below available on your controllers.

``` php
$sort = $this->getSort();
$order = $this->getOrder();
$limit = $this->getLimit();
$someOtherParameter = $this->getParameter('name', 'default value');
```