### PR TITLE
Fixed product transformer bug

### DIFF
--- a/webservice/app/Transformers/ProductTransformer.php
+++ b/webservice/app/Transformers/ProductTransformer.php
@@ -47,10 +47,12 @@ class ProductTransformer extends TransformerAbstract
      *
      * @param  Product $product
      *
-     * @return \League\Fractal\Resource\Item
+     * @return \League\Fractal\Resource\Item|null
      */
     public function includeCategory(Product $product)
     {
-        return $this->item($product->category, new CategoryTransformer);
+        if ($product->category) {
+            return $this->item($product->category, new CategoryTransformer);
+        }
     }
 }


### PR DESCRIPTION
Fixed the bug #89, the problem was that one product didn't have a category, the API wasn't expecting this situation, now if a product doesn't have a category, the product transformer just wont include the category.