### PR TITLE
Transformers configurations

### DIFF
--- a/webservice/app/Http/Controllers/AuthController.php
+++ b/webservice/app/Http/Controllers/AuthController.php
@@ -6,7 +6,6 @@ use Auth;
 use Lang;
 use App\Services\Jwt;
 use Illuminate\Http\Request;
-use App\Transformers\UserTransformer;
 use Illuminate\Foundation\Auth\ThrottlesLogins;
 
 class AuthController extends ApiController
@@ -58,7 +57,7 @@ class AuthController extends ApiController
         $this->clearLoginAttempts($request);
 
         // Get current user authenticated.
-        $user = $this->response->transform->item(Auth::guard('api')->user(), new UserTransformer());
+        $user = $this->response->transform->item(Auth::guard('api')->user());
 
         // get time to live of token form JWT service.
         $token_ttl = (new Jwt($token))->getTokenTTL();

--- a/webservice/app/Http/Controllers/CategoriesController.php
+++ b/webservice/app/Http/Controllers/CategoriesController.php
@@ -4,7 +4,6 @@ namespace App\Http\Controllers;
 
 use App\Category;
 use App\Http\Requests\CategoryRequest;
-use App\Transformers\CategoryTransformer;
 
 class CategoriesController extends ApiController
 {
@@ -21,7 +20,7 @@ class CategoriesController extends ApiController
 
         $categories = Category::orderBy($sort, $order)->paginate($limit);
 
-        return $this->response->collection($categories, new CategoryTransformer);
+        return $this->response->collection($categories);
     }
 
     /**
@@ -31,7 +30,7 @@ class CategoriesController extends ApiController
      */
     public function fullList()
     {
-        return $this->response->collection(Category::all(), new CategoryTransformer);
+        return $this->response->collection(Category::all());
     }
 
     /**
@@ -44,7 +43,7 @@ class CategoriesController extends ApiController
     {
         $category = Category::create($request->all());
 
-        return $this->response->withCreated($category, new CategoryTransformer);
+        return $this->response->withCreated($category);
     }
 
     /**
@@ -61,7 +60,7 @@ class CategoriesController extends ApiController
             return $this->response->withNotFound('Category not found');
         }
 
-        return $this->response->item($category, new CategoryTransformer);
+        return $this->response->item($category);
     }
 
     /**
@@ -81,7 +80,7 @@ class CategoriesController extends ApiController
 
         $category->fill($request->all())->save();
 
-        return $this->response->item($category, new CategoryTransformer);
+        return $this->response->item($category);
     }
 
     /**

--- a/webservice/app/Http/Controllers/MeController.php
+++ b/webservice/app/Http/Controllers/MeController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Support\Facades\Auth;
-use App\Transformers\UserTransformer;
 
 class MeController extends ApiController
 {
@@ -16,6 +15,6 @@ class MeController extends ApiController
     {
         $user = Auth::guard('api')->user();
 
-        return $this->response->item($user, new UserTransformer);
+        return $this->response->item($user);
     }
 }

--- a/webservice/app/Http/Controllers/ProductsController.php
+++ b/webservice/app/Http/Controllers/ProductsController.php
@@ -4,7 +4,6 @@ namespace App\Http\Controllers;
 
 use App\Product;
 use App\Http\Requests\ProductRequest;
-use App\Transformers\ProductTransformer;
 
 class ProductsController extends ApiController
 {
@@ -21,7 +20,7 @@ class ProductsController extends ApiController
 
         $products = Product::orderBy($sort, $order)->paginate($limit);
 
-        return $this->response->collection($products, new ProductTransformer);
+        return $this->response->collection($products);
     }
 
     /**
@@ -37,7 +36,7 @@ class ProductsController extends ApiController
             'category_id' => $request->category,
         ]);
 
-        return $this->response->withCreated($product, new ProductTransformer);
+        return $this->response->withCreated($product);
     }
 
     /**
@@ -54,7 +53,7 @@ class ProductsController extends ApiController
             return $this->response->withNotFound('Product not found');
         }
 
-        return $this->response->item($product, new ProductTransformer);
+        return $this->response->item($product);
     }
 
     /**
@@ -77,7 +76,7 @@ class ProductsController extends ApiController
             'category_id' => $request->category,
         ])->save();
 
-        return $this->response->item($product, new ProductTransformer);
+        return $this->response->item($product);
     }
 
     /**

--- a/webservice/app/Providers/AppServiceProvider.php
+++ b/webservice/app/Providers/AppServiceProvider.php
@@ -3,7 +3,7 @@
 namespace App\Providers;
 
 use League\Fractal\Manager;
-use App\Transformers\Transform;
+use App\Support\Transform;
 use Illuminate\Support\ServiceProvider;
 use League\Fractal\Serializer\DataArraySerializer;
 

--- a/webservice/app/Providers/AppServiceProvider.php
+++ b/webservice/app/Providers/AppServiceProvider.php
@@ -2,10 +2,9 @@
 
 namespace App\Providers;
 
-use League\Fractal\Manager;
 use App\Support\Transform;
+use League\Fractal\Manager;
 use Illuminate\Support\ServiceProvider;
-use League\Fractal\Serializer\DataArraySerializer;
 
 class AppServiceProvider extends ServiceProvider
 {

--- a/webservice/app/Providers/AppServiceProvider.php
+++ b/webservice/app/Providers/AppServiceProvider.php
@@ -26,14 +26,15 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->bind(Transform::class, function () {
+        $this->app->bind(Transform::class, function ($app) {
             $fractal = new Manager;
+            $serializer = $app['config']->get('api.serializer');
 
             if (request()->has('include')) {
                 $fractal->parseIncludes(request()->query('include'));
             }
 
-            $fractal->setSerializer(new DataArraySerializer);
+            $fractal->setSerializer(new $serializer);
 
             return new Transform($fractal);
         });

--- a/webservice/app/Support/Parameters.php
+++ b/webservice/app/Support/Parameters.php
@@ -15,6 +15,8 @@ class Parameters
 
     /**
      * Create a new class instance.
+     *
+     * @param Request $request
      */
     public function __construct(Request $request)
     {

--- a/webservice/app/Support/Response.php
+++ b/webservice/app/Support/Response.php
@@ -2,7 +2,7 @@
 
 namespace App\Support;
 
-use App\Transformers\Transform;
+use App\Support\Transform;
 use League\Fractal\TransformerAbstract;
 use Illuminate\Contracts\Routing\ResponseFactory;
 use Symfony\Component\HttpFoundation\Response as HttpResponse;
@@ -19,7 +19,7 @@ class Response
     /**
      * API transformer helper.
      *
-     * @var \App\Transformers\Transform
+     * @var \App\Support\Transform
      */
     public $transform;
 

--- a/webservice/app/Support/Response.php
+++ b/webservice/app/Support/Response.php
@@ -2,7 +2,6 @@
 
 namespace App\Support;
 
-use App\Support\Transform;
 use League\Fractal\TransformerAbstract;
 use Illuminate\Contracts\Routing\ResponseFactory;
 use Symfony\Component\HttpFoundation\Response as HttpResponse;

--- a/webservice/app/Support/Response.php
+++ b/webservice/app/Support/Response.php
@@ -58,10 +58,6 @@ class Response
             return $this->json();
         }
 
-        if (! $transformer) {
-            return $this->json($resource);
-        }
-
         return $this->item($resource, $transformer);
     }
 
@@ -150,12 +146,12 @@ class Response
     /**
      * Make a JSON response with the transformed item.
      *
-     * @param  mixed               $item
-     * @param  TransformerAbstract $transformer
+     * @param  mixed                    $item
+     * @param  TransformerAbstract|null $transformer
      *
      * @return \Illuminate\Http\JsonResponse
      */
-    public function item($item, TransformerAbstract $transformer)
+    public function item($item, TransformerAbstract $transformer = null)
     {
         return $this->json(
             $this->transform->item($item, $transformer)
@@ -165,12 +161,12 @@ class Response
     /**
      * Make a JSON response with the transformed items.
      *
-     * @param  mixed               $items
-     * @param  TransformerAbstract $transformer
+     * @param  mixed                    $items
+     * @param  TransformerAbstract|null $transformer
      *
      * @return \Illuminate\Http\JsonResponse
      */
-    public function collection($items, TransformerAbstract $transformer)
+    public function collection($items, TransformerAbstract $transformer = null)
     {
         return $this->json(
             $this->transform->collection($items, $transformer)

--- a/webservice/app/Support/Transform.php
+++ b/webservice/app/Support/Transform.php
@@ -4,8 +4,9 @@ namespace App\Support;
 
 use League\Fractal\Manager;
 use League\Fractal\TransformerAbstract;
-use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\Collection;
 use League\Fractal\Resource\Item as FractalItem;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use League\Fractal\Pagination\IlluminatePaginatorAdapter;
 use League\Fractal\Resource\Collection as FractalCollection;
 
@@ -29,13 +30,14 @@ class Transform
     /**
      * Transform a collection of data.
      *
-     * @param  mixed               $data
-     * @param  TransformerAbstract $transformer
+     * @param  mixed                    $data
+     * @param  TransformerAbstract|null $transformer
      *
      * @return array
      */
-    public function collection($data, TransformerAbstract $transformer)
+    public function collection($data, TransformerAbstract $transformer = null)
     {
+        $transformer = $transformer ?: $this->fetchDefaultTransformer($data);
         $collection = new FractalCollection($data, $transformer);
 
         if ($data instanceof LengthAwarePaginator) {
@@ -48,15 +50,63 @@ class Transform
     /**
      * Transform a single data.
      *
-     * @param  mixed               $data
-     * @param  TransformerAbstract $transformer
+     * @param  mixed                    $data
+     * @param  TransformerAbstract|null $transformer
      *
      * @return array
      */
-    public function item($data, TransformerAbstract $transformer)
+    public function item($data, TransformerAbstract $transformer = null)
     {
+        $transformer = $transformer ?: $this->fetchDefaultTransformer($data);
+
         return $this->fractal->createData(
             new FractalItem($data, $transformer)
         )->toArray();
+    }
+
+    /**
+     * Tries to fetch a default transformer for the given data.
+     *
+     * @param  mixed $data
+     *
+     * @return \League\Fractal\TransformerAbstract|null
+     */
+    protected function fetchDefaultTransformer($data)
+    {
+        $classname = $this->getClassnameFrom($data);
+
+        if ($this->hasDefaultTransformer($classname)) {
+            $transformer = config('api.transformers.'.$classname);
+
+            return new $transformer;
+        }
+    }
+
+    /**
+     * Check if the class has a default transformer.
+     *
+     * @param  string $classname
+     *
+     * @return bool
+     */
+    protected function hasDefaultTransformer($classname)
+    {
+        return ! is_null(config('api.transformers.'.$classname));
+    }
+
+    /**
+     * Get the class name from the given object.
+     *
+     * @param  object $object
+     *
+     * @return string
+     */
+    protected function getClassnameFrom($object)
+    {
+        if ($object instanceof LengthAwarePaginator or $object instanceof Collection) {
+            return get_class(array_first($object));
+        }
+
+        return get_class($object);
     }
 }

--- a/webservice/app/Support/Transform.php
+++ b/webservice/app/Support/Transform.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Transformers;
+namespace App\Support;
 
 use League\Fractal\Manager;
 use League\Fractal\TransformerAbstract;

--- a/webservice/config/api.php
+++ b/webservice/config/api.php
@@ -1,0 +1,21 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default transformers
+    |--------------------------------------------------------------------------
+    |
+    | Here you may register default transformers, this transformers will be
+    | used when you try to transform an eloquent model without specifying a
+    | transformer, feel free to register as many as you need.
+    |
+    */
+
+    'transformers' => [
+        App\User::class => App\Transformers\UserTransformer::class,
+        App\Product::class => App\Transformers\ProductTransformer::class,
+        App\Category::class => App\Transformers\CategoryTransformer::class,
+    ],
+];

--- a/webservice/config/api.php
+++ b/webservice/config/api.php
@@ -4,6 +4,24 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Data Serializer
+    |--------------------------------------------------------------------------
+    |
+    | Here you may choose the default data serializer to be used as the API
+    | output format, serializers let you switch between various output formats
+    | with minimal effect on your transformers.
+    |
+    | Supported: DataArraySerializer, ArraySerializer and JsonApiSerializer
+    |
+    | You can also create your own serializer, see more at the link below:
+    | http://fractal.thephpleague.com/serializers
+    |
+    */
+
+    'serializer' => League\Fractal\Serializer\DataArraySerializer::class,
+
+    /*
+    |--------------------------------------------------------------------------
     | Default transformers
     |--------------------------------------------------------------------------
     |

--- a/webservice/tests/Support/ResponseTest.php
+++ b/webservice/tests/Support/ResponseTest.php
@@ -1,8 +1,8 @@
 <?php
 
+use Illuminate\Http\JsonResponse;
 use App\Support\Response;
 use App\Support\Transform;
-use Illuminate\Http\JsonResponse;
 use League\Fractal\TransformerAbstract;
 use Illuminate\Contracts\Routing\ResponseFactory;
 use Illuminate\Foundation\Testing\WithoutMiddleware;
@@ -46,11 +46,11 @@ class ResponseTest extends TestCase
     /** @test */
     public function can_make_an_error_response()
     {
-        $response = $this->getResponseInstance()->withError('error');
+        $response = $this->getResponseInstance()->withError('message');
 
         $this->assertInstanceOf(JsonResponse::class, $response);
         $this->assertEquals([
-            'messages' => ['error'],
+            'messages' => ['message'],
         ], $response->getData(true));
     }
 
@@ -107,10 +107,10 @@ class ResponseTest extends TestCase
     /** @test */
     public function can_make_created_response()
     {
-        $response = $this->getResponseInstance()->withCreated(['test']);
+        $response = $this->getResponseInstance()->withCreated();
 
         $this->assertInstanceOf(JsonResponse::class, $response);
-        $this->assertEquals(['test'], $response->getData(true));
+        $this->assertEquals([], $response->getData(true));
         $this->assertEquals(201, $response->status());
     }
 

--- a/webservice/tests/Support/ResponseTest.php
+++ b/webservice/tests/Support/ResponseTest.php
@@ -1,7 +1,7 @@
 <?php
 
 use App\Support\Response;
-use App\Transformers\Transform;
+use App\Support\Transform;
 use Illuminate\Http\JsonResponse;
 use League\Fractal\TransformerAbstract;
 use Illuminate\Contracts\Routing\ResponseFactory;

--- a/webservice/tests/Support/TransformTest.php
+++ b/webservice/tests/Support/TransformTest.php
@@ -1,0 +1,90 @@
+<?php
+
+use App\Support\Transform;
+use League\Fractal\Manager;
+use League\Fractal\TransformerAbstract;
+use Illuminate\Foundation\Testing\WithoutMiddleware;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+
+class TransformTest extends TestCase
+{
+    /** @test */
+    public function can_transform_collection_with_pagination()
+    {
+        $data = Mockery::mock(LengthAwarePaginator::class, function ($mock) {
+            $mock->shouldReceive('currentPage', 'lastPage', 'total', 'count', 'perPage');
+        });
+
+        $transform = $this->getTransformInstance();
+        $transformer = $this->getTransformerMock(['data']);
+
+        $this->assertEquals([
+            'data' => [],
+            'meta' => [
+                'pagination' => [
+                    'total' => 0,
+                    'per_page' => 0,
+                    'current_page' => 0,
+                    'links' => [],
+                    'count' => 0,
+                    'total_pages' => 0,
+                ],
+            ],
+        ], $transform->collection($data, $transformer));
+    }
+
+    /** @test */
+    public function can_transform_collection()
+    {
+        $data = [
+            ['some data'], ['some data'], ['some data'],
+        ];
+
+        $transform = $this->getTransformInstance();
+        $transformer = $this->getTransformerMock(['data']);
+
+        return $this->assertEquals([
+            'data' => [
+                ['data'], ['data'], ['data']
+            ],
+        ], $transform->collection($data, $transformer));
+    }
+
+    /** @test */
+    public function can_transform_item()
+    {
+        $transform = $this->getTransformInstance();
+        $transformer = $this->getTransformerMock(['transformed data']);
+
+        return $this->assertEquals([
+            'data' => ['transformed data'],
+        ], $transform->item(['some data'], $transformer));
+    }
+
+    /**
+     * Get a transformer mock.
+     *
+     * @param  array  $transformedData
+     *
+     * @return \League\Fractal\TransformerAbstract
+     */
+    private function getTransformerMock($transformedData = [])
+    {
+        return Mockery::mock(TransformerAbstract::class, function ($mock) use ($transformedData) {
+            $mock->shouldReceive('setCurrentScope', 'getDefaultIncludes', 'getAvailableIncludes');
+            $mock->shouldReceive('transform')->andReturn($transformedData);
+        });
+    }
+
+    /**
+     * Get a fresh instance of the Transform class.
+     *
+     * @return \App\Support\Transform
+     */
+    private function getTransformInstance()
+    {
+        return resolve(Transform::class);
+    }
+}


### PR DESCRIPTION
Added the following configurations for the API transformers:

**Serializer**: The serializer class name to be used as an output format of the API.

**Transformers**: A default transformers list, making the transformer argument optional when transforming an eloquent model.