### PR TITLE
Fix the localforage warning on windows

### DIFF
--- a/client/build/webpack.base.conf.js
+++ b/client/build/webpack.base.conf.js
@@ -34,7 +34,11 @@ module.exports = {
     fallback: [path.join(__dirname, '../node_modules')]
   },
   module: {
-    noParse: [new RegExp('node_modules/localforage/dist/localforage.js')],
+    // Fix the localforage warning on windows
+    noParse: [
+      new RegExp('node_modules/localforage/dist/localforage.js'),
+      /[\/\\]node_modules[\/\\]localforage[\/\\]dist[\/\\]localforage\.js$/,
+    ],
     loaders: [
       {
         test: /\.vue$/,


### PR DESCRIPTION
Fixed the warning that webpack thinks localforage.js is a pre-built javascript file on windows system.
I don't have a Mac or Linux machine so please test to make sure that it won't create any weird behaviors on the other systems.