### PR TITLE
Default jwt secret key on the test environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ before_script:
   - travis_retry composer self-update
   - travis_retry composer update --no-interaction --prefer-dist
   - php artisan key:gen
-  - php artisan jwt:secret -f
 
 script:
   - vendor/bin/phpunit

--- a/webservice/phpunit.xml
+++ b/webservice/phpunit.xml
@@ -26,5 +26,6 @@
         <env name="DB_CONNECTION" value="sqlite"/>
         <env name="DB_DATABASE" value=":memory:"/>
         <env name="MAIL_DRIVER" value="log"/>
+        <env name="JWT_SECRET" value="secret"/>
     </php>
 </phpunit>


### PR DESCRIPTION
Added the **JWT_SECRET** variable to the test environment, it makes the authentication tests less dependent on the secret key of the original env file.