### PR TITLE
Fix wrong computed property in v-show

### DIFF
--- a/client/src/components/general/alerts.vue
+++ b/client/src/components/general/alerts.vue
@@ -56,7 +56,7 @@
 
     <el-alert
       :title="formatedErrorMessage"
-      v-show="hasValidationMessage"
+      v-show="hasValidationMessages"
       type="warning"
       @close="dismiss('validation')"
       show-icon></el-alert>


### PR DESCRIPTION
Fix this Vue warning caused by a typo inside Alert component:
```
[Vue warn]: Property or method "hasValidationMessage" is not defined on the instance but referenced during render
```
